### PR TITLE
Replace font_google() with font_link() to fix Docker image failing to run

### DIFF
--- a/app.R
+++ b/app.R
@@ -80,8 +80,14 @@ ui <- page_navbar(
     secondary  = "#C3B8B2",
     "link-color"       = "#002454",
     "link-hover-color" = "#001538",
-    header_font = font_google("Oswald"),
-    base_font   = font_google("Merriweather Sans")
+    header_font = font_link(
+      "Oswald",
+      href = "https://fonts.googleapis.com/css2?family=Oswald&display=swap"
+    ),
+    base_font   = font_link(
+      "Merriweather Sans",
+      href = "https://fonts.googleapis.com/css2?family=Merriweather+Sans:wght@400;700&display=swap"
+    )
   ),
   navbar_options = navbar_options(bg = "#002454", theme = "dark"),
 


### PR DESCRIPTION
font_google() was causing the app to fail after pulling and running the Docker image.

This PR replaces it with font_link(), which instead has the browser load the font directly.